### PR TITLE
Add feature of including URIs to names in tree

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -38,12 +38,16 @@ def process_page(args: tuple) -> List[Dict]:
                 death_ts = item_data['died']['timespan'] 
                 if 'identified_by' in death_ts and death_ts['identified_by']:
                     death_year = death_ts['identified_by'][0]['content'][:4]
+
+            equivalents = item_data.get('equivalent', [])
+            equivalent_ids = [equiv['id'] for equiv in equivalents if 'id' in equiv]
             
             entry = {
                 'name': item_data["_label"],
                 'birth_year': birth_year,
                 'death_year': death_year,
                 'id': item_data.get('id', None),
+                'equivalent': equivalent_ids,
                 'page_number': page_num,
                 'item_number': j,
                 "type": "person"

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -30,6 +30,12 @@ def create_tree(entries, consider_dates=True):
                 
                 # Convert subgroup iterator to list for multiple uses
                 subgroup_list = list(subgroup)
+
+                for entry in subgroup_list:
+                    if entry.get('equivalent'):
+                        for uri in entry['equivalent']:
+                            Node(f"Equivalent URI: {uri}", parent=name_node)
+
                 
                 if consider_dates:
                     # Further group by dates

--- a/src/visualize.py
+++ b/src/visualize.py
@@ -43,8 +43,7 @@ def create_tree(entries, consider_dates=True):
 
                 for entry in subgroup_list:
                     if entry.get('equivalent'):
-                        for uri in entry['equivalent']:
-                            Node(f"Equivalent URI: {uri}", parent=name_node)
+                        Node(f"Equivalent URI: {entry['equivalent']}", parent=name_node)
 
                 
                 if consider_dates:


### PR DESCRIPTION
Adds URIs based on a priority list (internal first by likelihood of appearance, then external).

Only adds one URI at a time. 

If we need more sophistication, a next step could be: check equivalent uris for how many and what type (internal, etc) to try to determine the best "base" record, then include only the other uris that have not merged into that base record. 